### PR TITLE
[feat] 회원가입 + 로그인 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,11 @@ dependencies {
 
 	// spring security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cs/quizeloper/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/cs/quizeloper/global/config/WebSecurityConfig.java
@@ -8,6 +8,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -18,6 +20,12 @@ import java.util.List;
 @EnableWebSecurity
 public class WebSecurityConfig implements WebMvcConfigurer {
     private final LoginResolver loginResolver;
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http.csrf(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/cs/quizeloper/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/cs/quizeloper/global/config/WebSecurityConfig.java
@@ -3,6 +3,7 @@ package com.cs.quizeloper.global.config;
 import com.cs.quizeloper.global.resolver.LoginResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.WebSecurityConfigurer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -18,6 +19,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @EnableWebSecurity
+@Configuration
 public class WebSecurityConfig implements WebMvcConfigurer {
     private final LoginResolver loginResolver;
 

--- a/src/main/java/com/cs/quizeloper/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/cs/quizeloper/global/config/WebSecurityConfig.java
@@ -1,16 +1,23 @@
 package com.cs.quizeloper.global.config;
 
+import com.cs.quizeloper.global.resolver.LoginResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.WebSecurityConfigurer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @EnableWebSecurity
-public class WebSecurityConfig{
+public class WebSecurityConfig implements WebMvcConfigurer {
+    private final LoginResolver loginResolver;
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http.csrf(AbstractHttpConfigurer::disable)
@@ -18,5 +25,10 @@ public class WebSecurityConfig{
                 .headers(h -> h.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
                 .formLogin(AbstractHttpConfigurer::disable)
                 .build();
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginResolver);
     }
 }

--- a/src/main/java/com/cs/quizeloper/global/constant/Constant.java
+++ b/src/main/java/com/cs/quizeloper/global/constant/Constant.java
@@ -3,7 +3,7 @@ package com.cs.quizeloper.global.constant;
 public class Constant {
     public static class Jwt {
         public static final String AUTHORIZATION_HEADER = "Authorization";
-        public static final String BEARER_PREFIX = "bearer";
+        public static final String BEARER_PREFIX = "bearer ";
         public static final String CLAIM_NAME = "userIdx";
     }
 }

--- a/src/main/java/com/cs/quizeloper/global/constant/Constant.java
+++ b/src/main/java/com/cs/quizeloper/global/constant/Constant.java
@@ -1,0 +1,9 @@
+package com.cs.quizeloper.global.constant;
+
+public class Constant {
+    public static class Jwt {
+        public static final String AUTHORIZATION_HEADER = "Authorization";
+        public static final String BEARER_PREFIX = "bearer";
+        public static final String CLAIM_NAME = "userIdx";
+    }
+}

--- a/src/main/java/com/cs/quizeloper/global/entity/BaseEntity.java
+++ b/src/main/java/com/cs/quizeloper/global/entity/BaseEntity.java
@@ -4,20 +4,23 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {
     @Enumerated(EnumType.STRING)
-    private BaseStatus status;
+    private BaseStatus status = BaseStatus.ACTIVE;
 
     @CreatedDate
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdDate;
+    @Column(updatable = false)
+    private LocalDateTime createdDate = LocalDateTime.MIN;
 
     @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime lastModifiedDate;
+    @Column
+    private LocalDateTime lastModifiedDate = LocalDateTime.MIN;
 }

--- a/src/main/java/com/cs/quizeloper/global/exception/AppExceptionHandler.java
+++ b/src/main/java/com/cs/quizeloper/global/exception/AppExceptionHandler.java
@@ -2,10 +2,11 @@ package com.cs.quizeloper.global.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Objects;
 
 @RestControllerAdvice
 public class AppExceptionHandler {
@@ -18,6 +19,6 @@ public class AppExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ResponseEntity<BaseResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(new BaseResponse<>(e.getStatusCode().value(), e.getMessage()));
+                .body(new BaseResponse<>(e.getStatusCode().value(), Objects.requireNonNull(e.getFieldError()).getDefaultMessage()));
     }
 }

--- a/src/main/java/com/cs/quizeloper/global/exception/BaseResponseStatus.java
+++ b/src/main/java/com/cs/quizeloper/global/exception/BaseResponseStatus.java
@@ -17,6 +17,7 @@ public enum BaseResponseStatus {
 
     // user
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다. "),
+    INVALID_USER_PASSWORD(HttpStatus.NOT_FOUND, "비밀번호가 일치하지 않습니다. "),
     DUPLICATE_USER_EMAIL(HttpStatus.BAD_REQUEST, "중복된 이메일입니다. "),
     DUPLICATE_USER_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다. "),
 

--- a/src/main/java/com/cs/quizeloper/global/exception/BaseResponseStatus.java
+++ b/src/main/java/com/cs/quizeloper/global/exception/BaseResponseStatus.java
@@ -17,6 +17,8 @@ public enum BaseResponseStatus {
 
     // user
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다. "),
+    DUPLICATE_USER_EMAIL(HttpStatus.BAD_REQUEST, "중복된 이메일입니다. "),
+    DUPLICATE_USER_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다. "),
 
     PAGE_COUNT_UNDER(HttpStatus.NOT_FOUND,"페이지는 0 이하로 입력할 수 없습니다."),
     PAGE_SIZE_COUNT_UNDER(HttpStatus.NOT_FOUND,"페이지에 들어가는 개수는 1 이하로 입력할 수 없습니다."),

--- a/src/main/java/com/cs/quizeloper/global/exception/BaseResponseStatus.java
+++ b/src/main/java/com/cs/quizeloper/global/exception/BaseResponseStatus.java
@@ -6,6 +6,18 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum BaseResponseStatus {
     SUCCESS(HttpStatus.OK, "요청에 성공했습니다."),
+    // jwt
+    NULL_TOKEN(HttpStatus.UNAUTHORIZED, "토큰 값을 입력해주세요."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰 값입니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 형식의 토큰 값입니다."),
+    MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 구조의 토큰 값입니다."),
+    EXPIRED_TOKEN(HttpStatus.FORBIDDEN, "만료된 토큰 값입니다."),
+    REQUIRED_AUTH_ANNOTATION(HttpStatus.FORBIDDEN, "auth annotation 을 붙여주세요."),
+    NOT_ACCESS_HEADER(HttpStatus.INTERNAL_SERVER_ERROR, "헤더에 접근할 수 없습니다."),
+
+    // user
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다. "),
+
     PAGE_COUNT_UNDER(HttpStatus.NOT_FOUND,"페이지는 0 이하로 입력할 수 없습니다."),
     PAGE_SIZE_COUNT_UNDER(HttpStatus.NOT_FOUND,"페이지에 들어가는 개수는 1 이하로 입력할 수 없습니다."),
     PAGE_COUNT_OVER(HttpStatus.NOT_FOUND,"조회 가능한 페이지수를 초과했습니다.");

--- a/src/main/java/com/cs/quizeloper/global/jwt/JwtService.java
+++ b/src/main/java/com/cs/quizeloper/global/jwt/JwtService.java
@@ -1,0 +1,85 @@
+package com.cs.quizeloper.global.jwt;
+
+import com.cs.quizeloper.global.constant.Constant;
+import com.cs.quizeloper.global.exception.BaseException;
+import com.cs.quizeloper.global.exception.BaseResponseStatus;
+import com.cs.quizeloper.global.jwt.dto.TokenDto;
+import com.cs.quizeloper.user.entity.Role;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+import static com.cs.quizeloper.global.constant.Constant.Jwt.BEARER_PREFIX;
+import static com.cs.quizeloper.global.constant.Constant.Jwt.CLAIM_NAME;
+
+
+@Component
+public class JwtService {
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
+
+    private final Key key;
+
+    public JwtService(@Value("${jwt.secret}") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    // token 생성
+    public TokenDto createToken(Long userIdx, Role role){
+        long now = new Date().getTime();
+        String accessToken = Jwts.builder()
+                .claim(CLAIM_NAME, userIdx)
+                .setSubject(userIdx.toString())
+                .setExpiration(new Date(now + ACCESS_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        // todo redis refresh token 적용
+
+        return TokenDto.toDto(BEARER_PREFIX + accessToken, BEARER_PREFIX + refreshToken, role);
+    }
+
+    // 토큰 유효성 검사
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException e) {
+            throw new BaseException(BaseResponseStatus.INVALID_TOKEN);
+        } catch (MalformedJwtException e){
+            throw new BaseException(BaseResponseStatus.MALFORMED_TOKEN);
+        } catch (ExpiredJwtException e) {
+            throw new BaseException(BaseResponseStatus.EXPIRED_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            throw new BaseException(BaseResponseStatus.UNSUPPORTED_TOKEN);
+        } catch (IllegalArgumentException e) {
+            throw new BaseException(BaseResponseStatus.NULL_TOKEN);
+        }
+    }
+
+    // 토큰 정보 불러오기
+    public Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    public Long getUserIdFromJWT(String accessToken){
+        String userId = (String) parseClaims(accessToken).get(Constant.Jwt.CLAIM_NAME);
+        return Long.parseLong(userId);
+    }
+}

--- a/src/main/java/com/cs/quizeloper/global/jwt/JwtService.java
+++ b/src/main/java/com/cs/quizeloper/global/jwt/JwtService.java
@@ -8,7 +8,6 @@ import com.cs.quizeloper.user.entity.Role;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/cs/quizeloper/global/jwt/dto/TokenDto.java
+++ b/src/main/java/com/cs/quizeloper/global/jwt/dto/TokenDto.java
@@ -1,0 +1,21 @@
+package com.cs.quizeloper.global.jwt.dto;
+
+import com.cs.quizeloper.user.entity.Role;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class TokenDto {
+    private String accessToken;
+    private String refreshToken;
+    private Role role;
+
+    public static TokenDto toDto(String accessToken, String refreshToken, Role role){
+        return TokenDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .role(role)
+                .build();
+    }
+}

--- a/src/main/java/com/cs/quizeloper/global/resolver/Account.java
+++ b/src/main/java/com/cs/quizeloper/global/resolver/Account.java
@@ -1,0 +1,11 @@
+package com.cs.quizeloper.global.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Account {
+}

--- a/src/main/java/com/cs/quizeloper/global/resolver/Auth.java
+++ b/src/main/java/com/cs/quizeloper/global/resolver/Auth.java
@@ -1,0 +1,11 @@
+package com.cs.quizeloper.global.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Auth {
+}

--- a/src/main/java/com/cs/quizeloper/global/resolver/LoginResolver.java
+++ b/src/main/java/com/cs/quizeloper/global/resolver/LoginResolver.java
@@ -1,0 +1,57 @@
+package com.cs.quizeloper.global.resolver;
+
+import com.cs.quizeloper.global.exception.BaseException;
+import com.cs.quizeloper.global.exception.BaseResponseStatus;
+import com.cs.quizeloper.global.jwt.JwtService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static com.cs.quizeloper.global.constant.Constant.Jwt.AUTHORIZATION_HEADER;
+import static com.cs.quizeloper.global.constant.Constant.Jwt.BEARER_PREFIX;
+import static com.cs.quizeloper.global.exception.BaseResponseStatus.*;
+
+@RequiredArgsConstructor
+@Component
+public class LoginResolver implements HandlerMethodArgumentResolver {
+    private final JwtService jwtService;
+
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Account.class) && String.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+        // annotation 확인
+        Auth auth = parameter.getParameterAnnotation(Auth.class);
+        if (auth == null) throw new BaseException(BaseResponseStatus.REQUIRED_AUTH_ANNOTATION);
+
+        // servletRequest 확인
+        HttpServletRequest httpServletRequest = webRequest.getNativeRequest(HttpServletRequest.class);
+        if(httpServletRequest == null) throw new BaseException(NOT_ACCESS_HEADER);
+        // header 안에 값이 있는지 확인
+        String token = httpServletRequest.getHeader(AUTHORIZATION_HEADER);
+        if (!StringUtils.hasText(token)){
+            throw new BaseException(NULL_TOKEN);
+        }
+
+        // user 값 추출
+        token = token.replace(BEARER_PREFIX, "");
+        if(jwtService.validateToken(token)){
+            return UserInfo.toDto(jwtService.getUserIdFromJWT(token));
+        } else{
+            throw new BaseException(USER_NOT_FOUND);
+        }
+    }
+
+
+}

--- a/src/main/java/com/cs/quizeloper/global/resolver/UserInfo.java
+++ b/src/main/java/com/cs/quizeloper/global/resolver/UserInfo.java
@@ -1,0 +1,15 @@
+package com.cs.quizeloper.global.resolver;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@Builder
+public class UserInfo {
+    private Long id;
+
+    public static UserInfo toDto(Long id){
+        return UserInfo.builder().id(id).build();
+    }
+}

--- a/src/main/java/com/cs/quizeloper/user/Repository/UserRepository.java
+++ b/src/main/java/com/cs/quizeloper/user/Repository/UserRepository.java
@@ -1,9 +1,12 @@
 package com.cs.quizeloper.user.Repository;
 
+import com.cs.quizeloper.global.entity.BaseStatus;
 import com.cs.quizeloper.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Boolean existsByEmailAndStatus(String email, BaseStatus status);
+    Boolean existsByNicknameAndStatus(String email, BaseStatus status);
 }

--- a/src/main/java/com/cs/quizeloper/user/Repository/UserRepository.java
+++ b/src/main/java/com/cs/quizeloper/user/Repository/UserRepository.java
@@ -5,8 +5,11 @@ import com.cs.quizeloper.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Boolean existsByEmailAndStatus(String email, BaseStatus status);
-    Boolean existsByNicknameAndStatus(String email, BaseStatus status);
+    Boolean existsByNicknameAndStatus(String nickname, BaseStatus status);
+    Optional<User> findByEmailAndStatus(String email, BaseStatus status);
 }

--- a/src/main/java/com/cs/quizeloper/user/controller/UserController.java
+++ b/src/main/java/com/cs/quizeloper/user/controller/UserController.java
@@ -1,7 +1,13 @@
 package com.cs.quizeloper.user.controller;
 
+import com.cs.quizeloper.global.exception.BaseResponse;
+import com.cs.quizeloper.global.jwt.dto.TokenDto;
+import com.cs.quizeloper.user.dto.SignupReq;
 import com.cs.quizeloper.user.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,4 +16,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
+
+    @PostMapping("signup")
+    public BaseResponse<TokenDto> signUp(@RequestBody @Valid SignupReq signupReq){
+        return new BaseResponse<>(userService.signUp(signupReq));
+    }
 }

--- a/src/main/java/com/cs/quizeloper/user/controller/UserController.java
+++ b/src/main/java/com/cs/quizeloper/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.cs.quizeloper.user.controller;
 
 import com.cs.quizeloper.global.exception.BaseResponse;
 import com.cs.quizeloper.global.jwt.dto.TokenDto;
+import com.cs.quizeloper.user.dto.LoginReq;
 import com.cs.quizeloper.user.dto.SignupReq;
 import com.cs.quizeloper.user.service.UserService;
 import jakarta.validation.Valid;
@@ -17,8 +18,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
     private final UserService userService;
 
-    @PostMapping("signup")
+    @PostMapping("/signup")
     public BaseResponse<TokenDto> signUp(@RequestBody @Valid SignupReq signupReq){
         return new BaseResponse<>(userService.signUp(signupReq));
+    }
+
+    @PostMapping("/login")
+    public BaseResponse<TokenDto> login(@RequestBody @Valid LoginReq loginReq){
+        return new BaseResponse<>(userService.login(loginReq));
     }
 }

--- a/src/main/java/com/cs/quizeloper/user/dto/LoginReq.java
+++ b/src/main/java/com/cs/quizeloper/user/dto/LoginReq.java
@@ -1,0 +1,19 @@
+package com.cs.quizeloper.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+
+@Data
+public class LoginReq {
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "올바르지 않은 이메일 형식입니다.")
+    private String email;
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,15}$",
+            message = "비밀번호를 숫자, 문자, 특수문자 포함 8~15자리 이내로 입력해주세요"
+    )
+    private String password;
+}

--- a/src/main/java/com/cs/quizeloper/user/dto/SignupReq.java
+++ b/src/main/java/com/cs/quizeloper/user/dto/SignupReq.java
@@ -1,0 +1,23 @@
+package com.cs.quizeloper.user.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.Data;
+
+@Data
+public class SignupReq {
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "올바르지 않은 이메일 형식입니다.")
+    private String email;
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,15}$",
+            message = "비밀번호를 숫자, 문자, 특수문자 포함 8~15자리 이내로 입력해주세요"
+    )
+    private String password;
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    @Size(
+            message = "닉네임을 두자리 이상 입력해주세요.",
+            min = 2
+    )
+    private String nickname;
+}

--- a/src/main/java/com/cs/quizeloper/user/entity/Role.java
+++ b/src/main/java/com/cs/quizeloper/user/entity/Role.java
@@ -1,0 +1,5 @@
+package com.cs.quizeloper.user.entity;
+
+public enum Role {
+    USR, ADMIN
+}

--- a/src/main/java/com/cs/quizeloper/user/entity/User.java
+++ b/src/main/java/com/cs/quizeloper/user/entity/User.java
@@ -26,10 +26,15 @@ public class User extends BaseEntity {
     @Column
     private String imgKey;
 
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
     @Builder
-    public User(String email, String password, String imgKey) {
+    public User(String email, String password, String imgKey, Role role) {
         this.email = email;
         this.password = password;
         this.imgKey = imgKey;
+        this.role = role;
     }
 }

--- a/src/main/java/com/cs/quizeloper/user/entity/User.java
+++ b/src/main/java/com/cs/quizeloper/user/entity/User.java
@@ -1,12 +1,14 @@
 package com.cs.quizeloper.user.entity;
 
 import com.cs.quizeloper.global.entity.BaseEntity;
+import com.cs.quizeloper.user.dto.SignupReq;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Where;
 
 @Getter
 @DynamicInsert
@@ -23,6 +25,9 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
+    @Column(nullable = false)
+    private String nickname;
+
     @Column
     private String imgKey;
 
@@ -31,10 +36,20 @@ public class User extends BaseEntity {
     private Role role;
 
     @Builder
-    public User(String email, String password, String imgKey, Role role) {
+    public User(String email, String password, String nickname, String imgKey, Role role) {
         this.email = email;
         this.password = password;
+        this.nickname = nickname;
         this.imgKey = imgKey;
         this.role = role;
+    }
+
+    public static User toEntity(SignupReq signupReq, Role role){
+        return User.builder()
+                .email(signupReq.getEmail())
+                .password(signupReq.getPassword())
+                .nickname(signupReq.getNickname())
+                .role(role)
+                .build();
     }
 }

--- a/src/main/java/com/cs/quizeloper/user/service/UserService.java
+++ b/src/main/java/com/cs/quizeloper/user/service/UserService.java
@@ -6,6 +6,7 @@ import com.cs.quizeloper.global.exception.BaseResponseStatus;
 import com.cs.quizeloper.global.jwt.JwtService;
 import com.cs.quizeloper.global.jwt.dto.TokenDto;
 import com.cs.quizeloper.user.Repository.UserRepository;
+import com.cs.quizeloper.user.dto.LoginReq;
 import com.cs.quizeloper.user.dto.SignupReq;
 import com.cs.quizeloper.user.entity.Role;
 import com.cs.quizeloper.user.entity.User;
@@ -32,4 +33,9 @@ public class UserService {
         return jwtService.createToken(user.getId(), user.getRole());
     }
 
+    public TokenDto login(LoginReq loginReq) {
+        User user = userRepository.findByEmailAndStatus(loginReq.getEmail(), BaseStatus.ACTIVE).orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
+        if(!passwordEncoder.matches(loginReq.getPassword(), user.getPassword())) throw new BaseException(BaseResponseStatus.INVALID_USER_PASSWORD);
+        return jwtService.createToken(user.getId(), user.getRole());
+    }
 }

--- a/src/main/java/com/cs/quizeloper/user/service/UserService.java
+++ b/src/main/java/com/cs/quizeloper/user/service/UserService.java
@@ -1,9 +1,35 @@
 package com.cs.quizeloper.user.service;
 
+import com.cs.quizeloper.global.entity.BaseStatus;
+import com.cs.quizeloper.global.exception.BaseException;
+import com.cs.quizeloper.global.exception.BaseResponseStatus;
+import com.cs.quizeloper.global.jwt.JwtService;
+import com.cs.quizeloper.global.jwt.dto.TokenDto;
+import com.cs.quizeloper.user.Repository.UserRepository;
+import com.cs.quizeloper.user.dto.SignupReq;
+import com.cs.quizeloper.user.entity.Role;
+import com.cs.quizeloper.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
+    private final PasswordEncoder passwordEncoder;
+
+    public TokenDto signUp(SignupReq signupReq) {
+        if (userRepository.existsByEmailAndStatus(signupReq.getEmail(), BaseStatus.ACTIVE)) throw new BaseException(BaseResponseStatus.DUPLICATE_USER_EMAIL);
+        if (userRepository.existsByNicknameAndStatus(signupReq.getNickname(), BaseStatus.ACTIVE)) throw new BaseException(BaseResponseStatus.DUPLICATE_USER_NICKNAME);
+
+        String password = signupReq.getPassword();
+        signupReq.setPassword(passwordEncoder.encode(password));
+        User user = User.toEntity(signupReq, Role.USR);
+        userRepository.save(user);
+
+        return jwtService.createToken(user.getId(), user.getRole());
+    }
+
 }


### PR DESCRIPTION
## 🌷 Issue Number
close #10 

<br>

## 📝 Explanation
- 로그인과 회원가입 그리고 jwt 에서 사용자 정보 불러오는 LoginResolver 생성해두었습니다
- secret.yaml 파일에 새롭게 코드가 추가되었으니 노션에서 확인해주세요 !
- `노션 -> 스택 -> 백엔드 -> secret 페이지에 저장되어 있습니다`

<br>

## 📝 Exception Situation
- 이메일, 비밀번호 정규 표현식이 알맞지 않은 경우 에러 발생
- 사용자 닉네임이 2글자 미만인 경우 에러 발생
