### PR TITLE
[feat] redis 설정 + 회원가입 닉네임 정규 표현식 + 토큰 재발급

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,10 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cs/quizeloper/global/config/RedisConfig.java
+++ b/src/main/java/com/cs/quizeloper/global/config/RedisConfig.java
@@ -1,0 +1,36 @@
+package com.cs.quizeloper.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    @Value("${redis.host}")
+    private String host;
+    @Value("${redis.port}")
+    private Integer port;
+    @Value("${redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        redisStandaloneConfiguration.setPassword(password);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/com/cs/quizeloper/global/jwt/JwtService.java
+++ b/src/main/java/com/cs/quizeloper/global/jwt/JwtService.java
@@ -85,4 +85,13 @@ public class JwtService {
         String userId = (String) parseClaims(accessToken).get(Constant.Jwt.CLAIM_NAME);
         return Long.parseLong(userId);
     }
+
+    public void validateRefreshToken(Long userId, String refreshToken){
+        String redisToken = redisService.getValue(userId.toString());
+        if(redisToken == null || !redisToken.equals(refreshToken)) throw new BaseException(BaseResponseStatus.INVALID_TOKEN);
+    }
+
+    public void deleteRefreshToken(Long userId) {
+        if(redisService.getValue(userId.toString()) != null) redisService.deleteValue(userId.toString());
+    }
 }

--- a/src/main/java/com/cs/quizeloper/global/jwt/JwtService.java
+++ b/src/main/java/com/cs/quizeloper/global/jwt/JwtService.java
@@ -4,6 +4,7 @@ import com.cs.quizeloper.global.constant.Constant;
 import com.cs.quizeloper.global.exception.BaseException;
 import com.cs.quizeloper.global.exception.BaseResponseStatus;
 import com.cs.quizeloper.global.jwt.dto.TokenDto;
+import com.cs.quizeloper.global.service.RedisService;
 import com.cs.quizeloper.user.entity.Role;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
+import java.time.Duration;
 import java.util.Date;
 
 import static com.cs.quizeloper.global.constant.Constant.Jwt.BEARER_PREFIX;
@@ -25,9 +27,12 @@ public class JwtService {
 
     private final Key key;
 
-    public JwtService(@Value("${jwt.secret}") String secretKey) {
+    private final RedisService redisService;
+
+    public JwtService(@Value("${jwt.secret}") String secretKey, RedisService redisService) {
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
         this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.redisService = redisService;
     }
 
     // token 생성
@@ -45,8 +50,7 @@ public class JwtService {
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
 
-        // todo redis refresh token 적용
-
+        redisService.setValue(userIdx.toString(), refreshToken, Duration.ofMillis(REFRESH_TOKEN_EXPIRE_TIME));
         return TokenDto.toDto(BEARER_PREFIX + accessToken, BEARER_PREFIX + refreshToken, role);
     }
 

--- a/src/main/java/com/cs/quizeloper/global/jwt/dto/TokenDto.java
+++ b/src/main/java/com/cs/quizeloper/global/jwt/dto/TokenDto.java
@@ -1,5 +1,6 @@
 package com.cs.quizeloper.global.jwt.dto;
 
+import com.cs.quizeloper.global.constant.Constant;
 import com.cs.quizeloper.user.entity.Role;
 import lombok.Builder;
 import lombok.Data;
@@ -17,5 +18,10 @@ public class TokenDto {
                 .refreshToken(refreshToken)
                 .role(role)
                 .build();
+    }
+
+    public void toReplaceDto(){
+        accessToken = accessToken.replace(Constant.Jwt.BEARER_PREFIX, "");
+        refreshToken = refreshToken.replace(Constant.Jwt.BEARER_PREFIX, "");
     }
 }

--- a/src/main/java/com/cs/quizeloper/global/service/RedisService.java
+++ b/src/main/java/com/cs/quizeloper/global/service/RedisService.java
@@ -1,0 +1,33 @@
+package com.cs.quizeloper.global.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RedisService {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void setValue(String key, String value, Duration time) {
+        redisTemplate.opsForValue().set(key, value, time);
+    }
+
+    public void setValue(String key, String value, Long exp, TimeUnit time){
+        redisTemplate.opsForValue().set(key, value, exp, time);
+    }
+
+    public String getValue(String key){
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    @Transactional
+    public void deleteValue(String key){
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/cs/quizeloper/user/Repository/UserRepository.java
+++ b/src/main/java/com/cs/quizeloper/user/Repository/UserRepository.java
@@ -12,4 +12,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Boolean existsByEmailAndStatus(String email, BaseStatus status);
     Boolean existsByNicknameAndStatus(String nickname, BaseStatus status);
     Optional<User> findByEmailAndStatus(String email, BaseStatus status);
+    Optional<User> findByIdAndStatus(Long id, BaseStatus status);
 }

--- a/src/main/java/com/cs/quizeloper/user/controller/UserController.java
+++ b/src/main/java/com/cs/quizeloper/user/controller/UserController.java
@@ -18,13 +18,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
     private final UserService userService;
 
+    // 회원 가입
     @PostMapping("/signup")
     public BaseResponse<TokenDto> signUp(@RequestBody @Valid SignupReq signupReq){
         return new BaseResponse<>(userService.signUp(signupReq));
     }
 
+    // 로그인
     @PostMapping("/login")
     public BaseResponse<TokenDto> login(@RequestBody @Valid LoginReq loginReq){
         return new BaseResponse<>(userService.login(loginReq));
+    }
+
+    // 토큰 재발급
+    @PostMapping("/reissue")
+    public BaseResponse<TokenDto> reissue(@RequestBody TokenDto tokenDto){
+        return new BaseResponse<>(userService.reissue(tokenDto));
     }
 }

--- a/src/main/java/com/cs/quizeloper/user/dto/SignupReq.java
+++ b/src/main/java/com/cs/quizeloper/user/dto/SignupReq.java
@@ -15,9 +15,9 @@ public class SignupReq {
     )
     private String password;
     @NotBlank(message = "닉네임을 입력해주세요.")
-    @Size(
-            message = "닉네임을 두자리 이상 입력해주세요.",
-            min = 2
+    @Pattern(
+            regexp = "^[가-힣ㄱ-ㅎa-zA-Z0-9._-]{6,}\\$",
+            message = "닉네임을 숫자, 문자를 포함하여 6자리 이상으로 입력해주세요 "
     )
     private String nickname;
 }


### PR DESCRIPTION
## 🌷 Issue Number
close #17

<br>

## 📝 Explanation
- redis 를 ec2에 생성함으로 인해 secret.yaml 파일에 관련 정보를 입력해두었으니 업데이트된 정보를 확인하여 배포 서버에 적용해주세요 !
- 닉네임 정규 표현식은 기획의도대로 한글, 영어, 숫자를 포함하여 6글자 이상 입력해야 합니다. 
- 토큰 재발급 API 도 생성해두었습니다.

<br>

## 📝 Exception Situation
- 닉네임 예외 처리 메시지 변경
- 사용자를 찾을 수 없는 경우 예외처리
- refreshToken이 유효하지 않은 토큰인 경우 예외처리
