### PR TITLE
[feat/refactor] 필터링된 문제 전체 조회

### DIFF
--- a/src/main/java/com/cs/quizeloper/quiz/Repository/QuizLikeRepository.java
+++ b/src/main/java/com/cs/quizeloper/quiz/Repository/QuizLikeRepository.java
@@ -2,15 +2,15 @@ package com.cs.quizeloper.quiz.Repository;
 
 import com.cs.quizeloper.global.entity.BaseStatus;
 import com.cs.quizeloper.quiz.entity.QuizLike;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 
 @Repository
 public interface QuizLikeRepository extends JpaRepository<QuizLike, Long> {
     @Query("SELECT e.id FROM QuizLike e")
-    Page<Long> findAllByUserAndStatus(Long userId, BaseStatus status, Pageable pageable);
+    List<Long> findAllByUserIdAndStatus(Long userId, BaseStatus status);
 }

--- a/src/main/java/com/cs/quizeloper/quiz/Repository/QuizRepository.java
+++ b/src/main/java/com/cs/quizeloper/quiz/Repository/QuizRepository.java
@@ -2,15 +2,22 @@ package com.cs.quizeloper.quiz.Repository;
 
 import com.cs.quizeloper.global.entity.BaseStatus;
 import com.cs.quizeloper.quiz.entity.Quiz;
+import com.cs.quizeloper.quiz.entity.QuizType;
+import com.cs.quizeloper.quiz.entity.Stack;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 
 @Repository
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
     Page<Quiz> findAllByStatus(BaseStatus status, Pageable pageable);
+    Page<Quiz> findAllByStatusAndStackUnit(BaseStatus status, Stack stack, Pageable pageable);
+    @Query("SELECT q.quiz FROM QuizUnitList q WHERE q.quiz.stackUnit = :stack and q.quizUnit.id in :unitRange and (q.quiz.type = :quizType or :quizType is null)")
+    Page<Quiz> findAllByStackAndQuizUnitIsNullAndQuizTypeIsNull(Pageable pageable, Stack stack, QuizType quizType, @Param("unitRange") Long ... unitRange);
+    @Query("SELECT q.quiz FROM QuizUnitList q WHERE (q.quiz.stackUnit = :stack or :stack is null) and (q.quiz.type = :quizType or :quizType is null)")
+    Page<Quiz> findAllByStackAndQuizTypeIsNull(Pageable pageable, Stack stack, QuizType quizType);
 }

--- a/src/main/java/com/cs/quizeloper/quiz/controller/QuizController.java
+++ b/src/main/java/com/cs/quizeloper/quiz/controller/QuizController.java
@@ -2,6 +2,8 @@ package com.cs.quizeloper.quiz.controller;
 
 import com.cs.quizeloper.global.exception.BaseException;
 import com.cs.quizeloper.global.exception.BaseResponse;
+import com.cs.quizeloper.global.resolver.Account;
+import com.cs.quizeloper.global.resolver.UserInfo;
 import com.cs.quizeloper.quiz.model.GetQuizRes;
 import com.cs.quizeloper.quiz.service.QuizService;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +26,7 @@ public class QuizController {
      */
     @ResponseBody
     @GetMapping("")
-    public BaseResponse<Page<GetQuizRes>> getQuizList(@RequestParam(name = "size", defaultValue = "16") Integer size,
+    public BaseResponse<Page<GetQuizRes>> getQuizList(@Account UserInfo userInfo, @RequestParam(name = "size", defaultValue = "16") Integer size,
                                                       @RequestParam(name = "page", defaultValue = "0") Integer page) {
         try {
             if (page < 0) {
@@ -34,7 +36,7 @@ public class QuizController {
                 return new BaseResponse<>(PAGE_SIZE_COUNT_UNDER);
             }
             PageRequest pageRequest = PageRequest.of(page, size);
-            Page<GetQuizRes> quizPage = quizService.getQuizList(pageRequest);
+            Page<GetQuizRes> quizPage = quizService.getQuizList(userInfo.getId(), pageRequest);
             return new BaseResponse<>(quizPage);
         } catch (BaseException exception){
             return new BaseResponse<>(exception.getStatus());

--- a/src/main/java/com/cs/quizeloper/quiz/controller/QuizController.java
+++ b/src/main/java/com/cs/quizeloper/quiz/controller/QuizController.java
@@ -1,6 +1,5 @@
 package com.cs.quizeloper.quiz.controller;
 
-import com.cs.quizeloper.global.exception.BaseException;
 import com.cs.quizeloper.global.exception.BaseResponse;
 import com.cs.quizeloper.global.resolver.Account;
 import com.cs.quizeloper.global.resolver.UserInfo;
@@ -10,9 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.*;
-
-import static com.cs.quizeloper.global.exception.BaseResponseStatus.PAGE_COUNT_UNDER;
-import static com.cs.quizeloper.global.exception.BaseResponseStatus.PAGE_SIZE_COUNT_UNDER;
 
 @RestController
 @RequestMapping("/quizzes")
@@ -28,18 +24,22 @@ public class QuizController {
     @GetMapping("")
     public BaseResponse<Page<GetQuizRes>> getQuizList(@Account UserInfo userInfo, @RequestParam(name = "size", defaultValue = "16") Integer size,
                                                       @RequestParam(name = "page", defaultValue = "0") Integer page) {
-        try {
-            if (page < 0) {
-                return new BaseResponse<>(PAGE_COUNT_UNDER);
-            }
-            if (size < 1) {
-                return new BaseResponse<>(PAGE_SIZE_COUNT_UNDER);
-            }
-            PageRequest pageRequest = PageRequest.of(page, size);
-            Page<GetQuizRes> quizPage = quizService.getQuizList(userInfo.getId(), pageRequest);
-            return new BaseResponse<>(quizPage);
-        } catch (BaseException exception){
-            return new BaseResponse<>(exception.getStatus());
-        }
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<GetQuizRes> quizPage = quizService.getQuizList(userInfo.getId(), pageRequest);
+        return new BaseResponse<>(quizPage);
+    }
+
+    /**
+     * [GET] 조건별로 필터링한 퀴즈 목록 불러오기
+     * @return BaseResponse<GetQuizRes>
+     */
+    @ResponseBody
+    @GetMapping("/{stack}")
+    public BaseResponse<Page<GetQuizRes>> getFilteredQuizList(@RequestParam(name = "size", defaultValue = "16") Integer size, @RequestParam(name = "page", defaultValue = "0") Integer page,
+                                                          @Account UserInfo userInfo, @PathVariable String stack,
+                                                          @RequestParam(name = "quizType", required = false) String quizType, @RequestParam(name = "range", required = false) Long ... range) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<GetQuizRes> quizPage = quizService.getFilteredQuizList(userInfo.getId(), stack, quizType, pageRequest, range);
+        return new BaseResponse<>(quizPage);
     }
 }

--- a/src/main/java/com/cs/quizeloper/quiz/service/QuizService.java
+++ b/src/main/java/com/cs/quizeloper/quiz/service/QuizService.java
@@ -1,5 +1,6 @@
 package com.cs.quizeloper.quiz.service;
 
+import com.cs.quizeloper.global.resolver.UserInfo;
 import com.cs.quizeloper.quiz.Repository.QuizLikeRepository;
 import com.cs.quizeloper.quiz.Repository.QuizRepository;
 import com.cs.quizeloper.quiz.entity.*;
@@ -24,27 +25,29 @@ public class QuizService {
 
     // 퀴즈 전체 목록 조회
     @Transactional
-    public Page<GetQuizRes> getQuizList(PageRequest pageRequest) {
+    public Page<GetQuizRes> getQuizList(Long userId, PageRequest pageRequest) {
         Page<Quiz> pagingQuiz = quizRepository.findAllByStatus(ACTIVE, pageRequest);
-        Page<Long> quizLikes = quizLikeRepository.findAllByUserAndStatus(1L, ACTIVE, pageRequest);
+        Page<Long> quizLikes = quizLikeRepository.findAllByUserAndStatus(userId, ACTIVE, pageRequest);
 
-        // List 형식의 QuizUnit 값 String 배열에 담기
-        List<String> quizString = pagingQuiz.getContent().stream()
-                .flatMap(quiz -> quiz.getQuizUnitList().stream().map(QuizUnitList::getQuizUnit))
-                .map(quizUnit -> String.valueOf(quizUnit.getUnit()))
-                .collect(Collectors.toList());
+        List<String> quizString = getQuizUnitList(pagingQuiz.getContent());
 
-        // 최종적으로 DTO에 반환
         List<GetQuizRes> quizResList = pagingQuiz.getContent().stream()
                 .map(quiz -> new GetQuizRes(quiz.getId(), quiz.getTitle(), quiz.getType(), quiz.getStackUnit(), quizString,
                         checkUserLikesQuiz(quizLikes.toList(), quiz)))
                 .collect(Collectors.toList());
-
         return new PageImpl<>(quizResList, pageRequest, pagingQuiz.getTotalElements());
     }
 
     // 퀴즈 좋아요 확인 여부
     private boolean checkUserLikesQuiz(List<Long> quizLike, Quiz quiz) {
         return quizLike.contains(quiz.getId());
+    }
+
+    // 퀴즈 문제 유형 반환
+    private List<String> getQuizUnitList(List<Quiz> quizList){
+        return quizList.stream()
+                .flatMap(quiz -> quiz.getQuizUnitList().stream().map(QuizUnitList::getQuizUnit))
+                .map(quizUnit -> String.valueOf(quizUnit.getUnit()))
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 🌷 Issue Number
close #15 

<br>

## 📝 Explanation
- 조건 설정에 따라 퀴즈 목록 조회 기능 제작했습니다. (카테고리는 필수 지정, 그 외 선택)
- [가변 인수 `Long ... range` (출제범위)의 경우](https://github.com/Quizeloper/quizeloper-server-user/pull/29/commits/dee86015011c557b50c6610f9d2d5cd39f2d4263#diff-b7282129f0b94a55be5241f8eff0a60ca59643460ad42e9f3e180923bf5c66a3R42-R59) null 조건에 따라 db 조회문을 분리하였습니다. (Query문에서 나누는 경우 배열 크기 확인시 정수값만 받아들임)
- 퀴즈 문제 유형 반환 메서드 `getQuizUnitList` 리팩토링 진행했습니다.
- 페이징 처리 부분 불필요한 코드 수정했습니다.
- 조건 설정에 따라 필터링하는 것은 프론트 분들께 질문 후 수정사항 있음 다시 최종적으로 반영하겠습니다! (이상 없을시 머지)
- [db에서 quizUnit id 조회하는 부분](https://github.com/Quizeloper/quizeloper-server-user/pull/29/commits/dee86015011c557b50c6610f9d2d5cd39f2d4263#diff-3807d5a67c779e4769bc0d8e308366b68c49d47d652bf4214e206c4dee6cd6d3R19-R22)은 어느 테이블에서 가져오느냐에 따라 시간 성능 차이가 있을 거 같아 추후에 유닛테스트 진행하며 다시 리팩토링 진행하겠습니다!

> 최대한 쿼리문을 안넣고 싶은데 연관 관계에 있는 테이블을 불러오다보니 불가피해졌습니다 우선은 pr 올리고 나중에 리팩토링 (무조건) 진행할 예정입니다 혹은 괜찮은 접근법 있으시면 알려주심 감사하겠습니다!
