### PR TITLE
[feat] 회원정보 수정 & 비밀번호 수정 API

### DIFF
--- a/src/main/java/com/cs/quizeloper/user/Repository/UserRepository.java
+++ b/src/main/java/com/cs/quizeloper/user/Repository/UserRepository.java
@@ -13,4 +13,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Boolean existsByNicknameAndStatus(String nickname, BaseStatus status);
     Optional<User> findByEmailAndStatus(String email, BaseStatus status);
     Optional<User> findByIdAndStatus(Long id, BaseStatus status);
+    Boolean existsByNicknameAndStatusAndIdNot(String email, BaseStatus status, Long id);
 }

--- a/src/main/java/com/cs/quizeloper/user/controller/UserController.java
+++ b/src/main/java/com/cs/quizeloper/user/controller/UserController.java
@@ -50,6 +50,14 @@ public class UserController {
         return new BaseResponse<>(BaseResponseStatus.SUCCESS);
     }
 
+    // 비밀번호 수정
+    @PatchMapping("/password")
+    public BaseResponse<BaseResponseStatus> patchPassword(@RequestBody @Valid LoginReq loginReq){
+        userService.patchPassword(loginReq);
+        return new BaseResponse<>(BaseResponseStatus.SUCCESS);
+    }
+
+
     // 이메일 중복 확인
     @PostMapping("/email/double-check")
     public BaseResponse<BaseResponseStatus> checkDuplicatedEmail(@RequestBody @Valid CheckDuplicatedEmailReq email){

--- a/src/main/java/com/cs/quizeloper/user/controller/UserController.java
+++ b/src/main/java/com/cs/quizeloper/user/controller/UserController.java
@@ -10,10 +10,7 @@ import com.cs.quizeloper.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/users")
@@ -66,4 +63,12 @@ public class UserController {
         userService.checkDuplicatedNickname(nickname.getNickname());
         return new BaseResponse<>(BaseResponseStatus.SUCCESS);
     }
+
+    // 회원정보 수정
+    @PatchMapping("/mypage")
+    public BaseResponse<BaseResponseStatus> patchMypage(@Account UserInfo userInfo, @RequestBody @Valid PatchMyPageReq myPageReq){
+        userService.patchMypage(userInfo.getId(), myPageReq);
+        return new BaseResponse<>(BaseResponseStatus.SUCCESS);
+    }
+
 }

--- a/src/main/java/com/cs/quizeloper/user/dto/PatchMyPageReq.java
+++ b/src/main/java/com/cs/quizeloper/user/dto/PatchMyPageReq.java
@@ -1,0 +1,22 @@
+package com.cs.quizeloper.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+
+@Data
+public class PatchMyPageReq {
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,15}$",
+            message = "비밀번호를 숫자, 문자, 특수문자 포함 8~15자리 이내로 입력해주세요"
+    )
+    private String password;
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    @Pattern(
+            regexp = "^(?=.*[a-z0-9가-힣])[a-z0-9가-힣]{6,}$",
+            message = "닉네임을 숫자, 문자를 사용하여 6자리 이상으로 입력해주세요 "
+    )
+    private String nickname;
+}

--- a/src/main/java/com/cs/quizeloper/user/dto/PatchMyPageReq.java
+++ b/src/main/java/com/cs/quizeloper/user/dto/PatchMyPageReq.java
@@ -19,4 +19,5 @@ public class PatchMyPageReq {
             message = "닉네임을 숫자, 문자를 사용하여 6자리 이상으로 입력해주세요 "
     )
     private String nickname;
+    private String imgKey;
 }

--- a/src/main/java/com/cs/quizeloper/user/entity/User.java
+++ b/src/main/java/com/cs/quizeloper/user/entity/User.java
@@ -60,4 +60,8 @@ public class User extends BaseEntity {
     public void setNickname(String nickname){
         this.nickname = nickname;
     }
+
+    public void setImgKey(String imgKey) {
+        this.imgKey = imgKey;
+    }
 }

--- a/src/main/java/com/cs/quizeloper/user/entity/User.java
+++ b/src/main/java/com/cs/quizeloper/user/entity/User.java
@@ -52,4 +52,12 @@ public class User extends BaseEntity {
                 .role(role)
                 .build();
     }
+
+    public void setPassword(String password){
+        this.password = password;
+    }
+
+    public void setNickname(String nickname){
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/cs/quizeloper/user/service/UserService.java
+++ b/src/main/java/com/cs/quizeloper/user/service/UserService.java
@@ -98,5 +98,17 @@ public class UserService {
         }
         // 닉네임 수정
         if(!user.getNickname().equals(myPageReq.getNickname())) user.setNickname(myPageReq.getNickname());
+        // 수정 저장
+        userRepository.save(user);
+    }
+
+    public void patchPassword(LoginReq loginReq) {
+        // 사용자 불러오기
+        User user = userRepository.findByEmailAndStatus(loginReq.getEmail(), BaseStatus.ACTIVE).orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
+        // 비밀번호 수정
+        String password = loginReq.getPassword();
+        user.setPassword(passwordEncoder.encode(password));
+        // 수정 저장
+        userRepository.save(user);
     }
 }

--- a/src/main/java/com/cs/quizeloper/user/service/UserService.java
+++ b/src/main/java/com/cs/quizeloper/user/service/UserService.java
@@ -98,6 +98,8 @@ public class UserService {
         }
         // 닉네임 수정
         if(!user.getNickname().equals(myPageReq.getNickname())) user.setNickname(myPageReq.getNickname());
+        // 이미지키가 다른 경우
+        if(!user.getImgKey().equals(myPageReq.getImgKey())) user.setImgKey(myPageReq.getImgKey());
         // 수정 저장
         userRepository.save(user);
     }

--- a/src/main/java/com/cs/quizeloper/user/service/UserService.java
+++ b/src/main/java/com/cs/quizeloper/user/service/UserService.java
@@ -8,6 +8,7 @@ import com.cs.quizeloper.global.jwt.JwtService;
 import com.cs.quizeloper.global.jwt.dto.TokenDto;
 import com.cs.quizeloper.user.Repository.UserRepository;
 import com.cs.quizeloper.user.dto.LoginReq;
+import com.cs.quizeloper.user.dto.PatchMyPageReq;
 import com.cs.quizeloper.user.dto.SignupReq;
 import com.cs.quizeloper.user.entity.Role;
 import com.cs.quizeloper.user.entity.User;
@@ -84,5 +85,18 @@ public class UserService {
         if (userRepository.existsByNicknameAndStatus(nickname, BaseStatus.ACTIVE)) throw new BaseException(BaseResponseStatus.DUPLICATE_USER_NICKNAME);
 
 
+    }
+
+    public void patchMypage(Long userId, PatchMyPageReq myPageReq) {
+        User user = userRepository.findByIdAndStatus(userId, BaseStatus.ACTIVE).orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
+        // 자기 자신 이외의 닉네임을 확인하여 동일한 닉네임이 존재하는 경우
+        if(userRepository.existsByNicknameAndStatusAndIdNot(myPageReq.getNickname(), BaseStatus.ACTIVE, userId)) throw new BaseException(BaseResponseStatus.DUPLICATE_USER_NICKNAME);
+        // 비밀번호 수정
+        if(!passwordEncoder.matches(user.getPassword(), myPageReq.getPassword())) {
+            String password = myPageReq.getPassword();
+            user.setPassword(passwordEncoder.encode(password));
+        }
+        // 닉네임 수정
+        if(!user.getNickname().equals(myPageReq.getNickname())) user.setNickname(myPageReq.getNickname());
     }
 }


### PR DESCRIPTION
## 🌷 Issue Number
close #30 

<br>

## 📝 Explanation
- 비밀번호 수정에서 로그인과 정보 불러오는 속성이 같아서 `LoginReq`을 사용했는데 네이밍을 변경해야 할 거 같아요! 좋은 의견 있음 말씀해주세요 ~!

<br>

## 📝 Exception Situation
- 사용자를 찾지 못한 경우
- 변경하고자 하는 사용자가 사용자 이외의 유저의 닉네임과 같은 경우
- 비밀번호 & 이메일 & 닉네임의 정규표현식이 올바르지 않은 경우
