### PR TITLE
[feat] 내 퀴즈 요약

### DIFF
--- a/src/main/java/com/cs/quizeloper/quiz/Repository/QuizHistoryRepository.java
+++ b/src/main/java/com/cs/quizeloper/quiz/Repository/QuizHistoryRepository.java
@@ -1,8 +1,12 @@
 package com.cs.quizeloper.quiz.Repository;
 
 import com.cs.quizeloper.global.entity.BaseStatus;
-import com.cs.quizeloper.quiz.entity.QuizHistory;
+import com.cs.quizeloper.quiz.entity.*;
+import com.cs.quizeloper.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,4 +14,15 @@ import java.util.Optional;
 @Repository
 public interface QuizHistoryRepository extends JpaRepository<QuizHistory, Long> {
     Optional<QuizHistory> findFirstByQuizIdAndUserIdAndStatusOrderByCreatedDateDesc(long quizId, long userId, BaseStatus ACTIVE);
+    @Query("SELECT q.quiz FROM QuizHistory q WHERE q.status = :status and q.quizStatus = :quizStatus and q.quiz.stackUnit = :stack and q.user = :user order by q.createdDate desc")
+    Page<Quiz> findAllByOrderByCreatedDateDesc(User user, Stack stack, QuizStatus quizStatus, BaseStatus status, Pageable pageable);
+    @Query("SELECT q.quiz FROM QuizHistory q WHERE q.status = :status and q.quizStatus = :quizStatus and q.quiz.stackUnit = :stack and q.user = :user order by q.createdDate asc")
+    Page<Quiz> findAllByOrderByCreatedDateAsc(User user, Stack stack, QuizStatus quizStatus, BaseStatus status, Pageable pageable);
+    @Query("SELECT q.quiz FROM QuizHistory q WHERE q.status = :status and q.quizStatus = :quizStatus and q.quiz.stackUnit = :stack and q.user = :user GROUP BY q.quiz order by count(q.quiz) desc ")
+    Page<Quiz> findAllByLarge(User user, Stack stack, QuizStatus quizStatus, BaseStatus status, Pageable pageable);
+    @Query("SELECT q.quiz FROM QuizHistory q WHERE q.status = :status and q.quizStatus = :quizStatus and q.quiz.stackUnit = :stack and q.user = :user GROUP BY q.quiz order by count(q.quiz) asc ")
+    Page<Quiz> findAllBySmall(User user, Stack stack, QuizStatus quizStatus, BaseStatus status, Pageable pageable);
+    @Query("SELECT q.quiz FROM QuizHistory q WHERE q.status = :status and q.quiz.stackUnit = :stack and q.user = :user")
+    Page<Quiz> findAll(User user, Stack stack, BaseStatus status, Pageable pageable);
+
 }

--- a/src/main/java/com/cs/quizeloper/quiz/Repository/QuizHistoryRepository.java
+++ b/src/main/java/com/cs/quizeloper/quiz/Repository/QuizHistoryRepository.java
@@ -14,15 +14,15 @@ import java.util.Optional;
 @Repository
 public interface QuizHistoryRepository extends JpaRepository<QuizHistory, Long> {
     Optional<QuizHistory> findFirstByQuizIdAndUserIdAndStatusOrderByCreatedDateDesc(long quizId, long userId, BaseStatus ACTIVE);
-    @Query("SELECT q.quiz FROM QuizHistory q WHERE q.status = :status and q.quizStatus = :quizStatus and q.quiz.stackUnit = :stack and q.user = :user order by q.createdDate desc")
+    @Query("SELECT q.quiz FROM QuizHistory q WHERE q.status = :status and q.quizStatus = :quizStatus and (:stack IS NULL OR q.quiz.stackUnit = :stack) and q.user = :user order by q.createdDate desc")
     Page<Quiz> findAllByOrderByCreatedDateDesc(User user, Stack stack, QuizStatus quizStatus, BaseStatus status, Pageable pageable);
-    @Query("SELECT q.quiz FROM QuizHistory q WHERE q.status = :status and q.quizStatus = :quizStatus and q.quiz.stackUnit = :stack and q.user = :user order by q.createdDate asc")
+    @Query("SELECT q.quiz FROM QuizHistory q WHERE q.status = :status and q.quizStatus = :quizStatus and (:stack IS NULL OR q.quiz.stackUnit = :stack) and q.user = :user order by q.createdDate asc")
     Page<Quiz> findAllByOrderByCreatedDateAsc(User user, Stack stack, QuizStatus quizStatus, BaseStatus status, Pageable pageable);
-    @Query("SELECT q.quiz FROM QuizHistory q WHERE q.status = :status and q.quizStatus = :quizStatus and q.quiz.stackUnit = :stack and q.user = :user GROUP BY q.quiz order by count(q.quiz) desc ")
+    @Query("SELECT q.quiz FROM QuizHistory q WHERE q.status = :status and q.quizStatus = :quizStatus and (:stack IS NULL OR q.quiz.stackUnit = :stack) and q.user = :user GROUP BY q.quiz order by count(q.quiz) desc ")
     Page<Quiz> findAllByLarge(User user, Stack stack, QuizStatus quizStatus, BaseStatus status, Pageable pageable);
-    @Query("SELECT q.quiz FROM QuizHistory q WHERE q.status = :status and q.quizStatus = :quizStatus and q.quiz.stackUnit = :stack and q.user = :user GROUP BY q.quiz order by count(q.quiz) asc ")
+    @Query("SELECT q.quiz FROM QuizHistory q WHERE q.status = :status and q.quizStatus = :quizStatus and (:stack IS NULL OR q.quiz.stackUnit = :stack) and q.user = :user GROUP BY q.quiz order by count(q.quiz) asc ")
     Page<Quiz> findAllBySmall(User user, Stack stack, QuizStatus quizStatus, BaseStatus status, Pageable pageable);
-    @Query("SELECT q.quiz FROM QuizHistory q WHERE q.status = :status and q.quiz.stackUnit = :stack and q.user = :user")
+    @Query("SELECT q.quiz FROM QuizHistory q WHERE q.status = :status and (:stack IS NULL OR q.quiz.stackUnit = :stack) and q.user = :user")
     Page<Quiz> findAll(User user, Stack stack, BaseStatus status, Pageable pageable);
 
 }

--- a/src/main/java/com/cs/quizeloper/quiz/Repository/QuizHistoryRepository.java
+++ b/src/main/java/com/cs/quizeloper/quiz/Repository/QuizHistoryRepository.java
@@ -25,4 +25,28 @@ public interface QuizHistoryRepository extends JpaRepository<QuizHistory, Long> 
     @Query("SELECT q.quiz FROM QuizHistory q WHERE q.status = :status and (:stack IS NULL OR q.quiz.stackUnit = :stack) and q.user = :user")
     Page<Quiz> findAll(User user, Stack stack, BaseStatus status, Pageable pageable);
 
+    @Query("SELECT COUNT(qh) FROM QuizHistory as qh WHERE qh.status = :status and qh.user = :user and FUNCTION('DATE', qh.createdDate) = FUNCTION('DATE', :date)")
+    Integer findAllHistoryNum(User user, String date, BaseStatus status);
+
+    @Query("SELECT COUNT(DISTINCT qh.quiz) FROM QuizHistory as qh WHERE qh.status = :status and qh.user = :user and FUNCTION('DATE', qh.createdDate) = FUNCTION('DATE', :date)")
+    Integer findSolvedHistoryNum(User user, String date, BaseStatus status);
+    @Query("""
+            SELECT COUNT(DISTINCT qh.quiz) as successNum
+            FROM QuizHistory as qh WHERE qh.status = :status and qh.user = :user AND FUNCTION('DATE', qh.createdDate) = FUNCTION('DATE', :date) AND qh.quizStatus = 'SUCCESS'""")
+    Integer findSuccessHistory(User user, String date, BaseStatus status);
+
+    @Query("""
+            SELECT COUNT(DISTINCT qh.quiz) as failureNum
+            FROM QuizHistory qh WHERE qh.status = :status and qh.user = :user AND FUNCTION('DATE', qh.createdDate) = FUNCTION('DATE', :date) AND qh.quizStatus = 'FAILURE'""")
+    Integer findFailureHistory(User user, String date, BaseStatus status);
+    @Query("SELECT COUNT(DISTINCT qh.quiz) FROM QuizHistory qh WHERE qh.status = :status and qh.user = :user and qh.quiz.stackUnit = :stack")
+    Double findSolveHistoryByStacks(User user, Stack stack, BaseStatus status);
+
+    @Query("SELECT COUNT(DISTINCT qh.quiz)\n" +
+            "FROM QuizHistory qh\n" +
+            "WHERE qh.status = :status\n" +
+            "  AND qh.user = :user\n" +
+            "  AND qh.quiz.stackUnit = :stack\n" +
+            "  AND qh.quizStatus = 'SUCCESS'")
+    Double findSuccessHistoryByStacks(User user, Stack stack, BaseStatus status);
 }

--- a/src/main/java/com/cs/quizeloper/quiz/Repository/QuizLikeRepository.java
+++ b/src/main/java/com/cs/quizeloper/quiz/Repository/QuizLikeRepository.java
@@ -1,7 +1,12 @@
 package com.cs.quizeloper.quiz.Repository;
 
 import com.cs.quizeloper.global.entity.BaseStatus;
+import com.cs.quizeloper.quiz.entity.Quiz;
 import com.cs.quizeloper.quiz.entity.QuizLike;
+import com.cs.quizeloper.quiz.entity.Stack;
+import com.cs.quizeloper.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -15,4 +20,6 @@ public interface QuizLikeRepository extends JpaRepository<QuizLike, Long> {
     List<Long> findAllByUserIdAndStatus(Long userId, BaseStatus status);
     Boolean existsIdByUserIdAndQuizId(Long userId, Long quizId);
     void deleteByUserIdAndQuizId(Long userId, Long quizId);
+    @Query("SELECT q.quiz FROM QuizLike q WHERE q.status = :status and q.quiz.stackUnit = :stack and q.user = :user")
+    Page<Quiz> findAllByOrderByCreatedDateDesc(User user, Stack stack, BaseStatus status, Pageable pageable);
 }

--- a/src/main/java/com/cs/quizeloper/quiz/Repository/QuizLikeRepository.java
+++ b/src/main/java/com/cs/quizeloper/quiz/Repository/QuizLikeRepository.java
@@ -22,4 +22,7 @@ public interface QuizLikeRepository extends JpaRepository<QuizLike, Long> {
     void deleteByUserIdAndQuizId(Long userId, Long quizId);
     @Query("SELECT q.quiz FROM QuizLike q WHERE q.status = :status and q.quiz.stackUnit = :stack and q.user = :user")
     Page<Quiz> findAllByOrderByCreatedDateDesc(User user, Stack stack, BaseStatus status, Pageable pageable);
+
+    @Query("SELECT q.quiz FROM QuizLike q WHERE q.status = :status and q.user = :user")
+    Page<Quiz> findAll(User user, BaseStatus status, Pageable pageable);
 }

--- a/src/main/java/com/cs/quizeloper/quiz/Repository/QuizRepository.java
+++ b/src/main/java/com/cs/quizeloper/quiz/Repository/QuizRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -23,4 +24,6 @@ public interface QuizRepository extends JpaRepository<Quiz, Long> {
     Page<Quiz> findAllByStackAndQuizUnitIsNullAndQuizTypeIsNull(Pageable pageable, Stack stack, QuizType quizType, @Param("unitRange") Long ... unitRange);
     @Query("SELECT q.quiz FROM QuizUnitList q WHERE (q.quiz.stackUnit = :stack or :stack is null) and (q.quiz.type = :quizType or :quizType is null)")
     Page<Quiz> findAllByStackAndQuizTypeIsNull(Pageable pageable, Stack stack, QuizType quizType);
+    @Query("SELECT COUNT(DISTINCT (CASE WHEN q.stackUnit= :stack THEN q.id END)) FROM Quiz q WHERE q.status = :status")
+    Double findAllStacks(Stack stack, BaseStatus status);
 }

--- a/src/main/java/com/cs/quizeloper/quiz/service/QuizService.java
+++ b/src/main/java/com/cs/quizeloper/quiz/service/QuizService.java
@@ -117,7 +117,7 @@ public class QuizService {
     // 퀴즈 답안 & 해설 조회
     public GetQuizAnsRes getQuizAnswer(long userId, long quizId) {
         QuizHistory quizHistory= quizHistoryRepository.findFirstByQuizIdAndUserIdAndStatusOrderByCreatedDateDesc(quizId, userId, ACTIVE).orElseThrow(() -> new BaseException(BaseResponseStatus.QUIZ_HISTORY_NOT_FOUND));
-        Quiz quiz = quizRepository.findByIdAndStatus(quizId, ACTIVE);
+        Quiz quiz = quizRepository.findByIdAndStatus(quizId, ACTIVE).orElseThrow(() -> new BaseException(BaseResponseStatus.QUIZ_NOT_FOUND));
         return GetQuizAnsRes.toDto(quiz, quizHistory);
     }
 

--- a/src/main/java/com/cs/quizeloper/user/controller/UserController.java
+++ b/src/main/java/com/cs/quizeloper/user/controller/UserController.java
@@ -108,4 +108,12 @@ public class UserController {
         Page<GetUserQuizRes> myQuizzes = userService.getQuizList(userInfo.getId(), pageable);
         return new BaseResponse<>(myQuizzes);
     }
+
+    @GetMapping("/myQuizzes/{stack}/solving/{solStatus}")
+    public BaseResponse<Page<GetUserQuizHistoryRes>> getMyQuizListByStack(@Account UserInfo userInfo, @PathVariable(required = false) String stack,
+                                                                          @RequestParam(required = false) String sorting,
+                                                                          @PathVariable String solStatus, Pageable pageable) {
+        Page<GetUserQuizHistoryRes> quizHistory = userService.getQuizHistoryList(userInfo.getId(), stack, sorting, solStatus, pageable);
+        return new BaseResponse<>(quizHistory);
+    }
 }

--- a/src/main/java/com/cs/quizeloper/user/controller/UserController.java
+++ b/src/main/java/com/cs/quizeloper/user/controller/UserController.java
@@ -10,6 +10,8 @@ import com.cs.quizeloper.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -93,4 +95,10 @@ public class UserController {
         return new BaseResponse<>(userService.getMypage(userInfo.getId()));
     }
 
+    // 스택별 좋아요 문제 불러오기
+    @GetMapping("/myQuizzes/{stack}/likes")
+    public BaseResponse<Page<GetUserQuizRes>> getMyQuizList(@Account UserInfo userInfo, @PathVariable String stack, Pageable pageable) {
+        Page<GetUserQuizRes> myQuizzes = userService.getMyQuizList(userInfo.getId(), stack, pageable);
+        return new BaseResponse<>(myQuizzes);
+    }
 }

--- a/src/main/java/com/cs/quizeloper/user/controller/UserController.java
+++ b/src/main/java/com/cs/quizeloper/user/controller/UserController.java
@@ -109,11 +109,20 @@ public class UserController {
         return new BaseResponse<>(myQuizzes);
     }
 
+    // 스택별 맞춘/틀린 문제 조회
     @GetMapping("/myQuizzes/{stack}/solving/{solStatus}")
-    public BaseResponse<Page<GetUserQuizHistoryRes>> getMyQuizListByStack(@Account UserInfo userInfo, @PathVariable(required = false) String stack,
+    public BaseResponse<Page<GetUserQuizHistoryRes>> getQuizHistoryByStack(@Account UserInfo userInfo, @PathVariable String stack,
                                                                           @RequestParam(required = false) String sorting,
                                                                           @PathVariable String solStatus, Pageable pageable) {
-        Page<GetUserQuizHistoryRes> quizHistory = userService.getQuizHistoryList(userInfo.getId(), stack, sorting, solStatus, pageable);
+        Page<GetUserQuizHistoryRes> quizHistory = userService.getQuizHistoryListByStack(userInfo.getId(), stack, sorting, solStatus, pageable);
+        return new BaseResponse<>(quizHistory);
+    }
+
+    // 전체 맞춘/틀린 문제 조회
+    @GetMapping("/myQuizzes/solving/{solStatus}")
+    public BaseResponse<Page<GetUserQuizHistoryRes>> getQuizHistory(@Account UserInfo userInfo, @RequestParam(required = false) String sorting,
+                                                                          @PathVariable String solStatus, Pageable pageable) {
+        Page<GetUserQuizHistoryRes> quizHistory = userService.getQuizHistoryList(userInfo.getId(), sorting, solStatus, pageable);
         return new BaseResponse<>(quizHistory);
     }
 }

--- a/src/main/java/com/cs/quizeloper/user/controller/UserController.java
+++ b/src/main/java/com/cs/quizeloper/user/controller/UserController.java
@@ -125,4 +125,10 @@ public class UserController {
         Page<GetUserQuizHistoryRes> quizHistory = userService.getQuizHistoryList(userInfo.getId(), sorting, solStatus, pageable);
         return new BaseResponse<>(quizHistory);
     }
+
+    // 내 퀴즈 요약
+    @GetMapping("/myQuizzes/{stack}")
+    public BaseResponse<GetMyQuizSummary> getMyQuizzesSummary(@Account UserInfo userInfo, @PathVariable String stack, @RequestParam String date) {
+        return new BaseResponse<>(userService.getQuizSummary(userInfo.getId(), stack, date));
+    }
 }

--- a/src/main/java/com/cs/quizeloper/user/controller/UserController.java
+++ b/src/main/java/com/cs/quizeloper/user/controller/UserController.java
@@ -97,8 +97,15 @@ public class UserController {
 
     // 스택별 좋아요 문제 불러오기
     @GetMapping("/myQuizzes/{stack}/likes")
-    public BaseResponse<Page<GetUserQuizRes>> getMyQuizList(@Account UserInfo userInfo, @PathVariable String stack, Pageable pageable) {
-        Page<GetUserQuizRes> myQuizzes = userService.getMyQuizList(userInfo.getId(), stack, pageable);
+    public BaseResponse<Page<GetUserQuizRes>> getMyQuizListByStack(@Account UserInfo userInfo, @PathVariable String stack, Pageable pageable) {
+        Page<GetUserQuizRes> myQuizzes = userService.getQuizListByStack(userInfo.getId(), stack, pageable);
+        return new BaseResponse<>(myQuizzes);
+    }
+
+    // 좋아요 문제 불러오기
+    @GetMapping("/myQuizzes/likes")
+    public BaseResponse<Page<GetUserQuizRes>> getMyQuizList(@Account UserInfo userInfo, Pageable pageable) {
+        Page<GetUserQuizRes> myQuizzes = userService.getQuizList(userInfo.getId(), pageable);
         return new BaseResponse<>(myQuizzes);
     }
 }

--- a/src/main/java/com/cs/quizeloper/user/dto/GetMyQuizSummary.java
+++ b/src/main/java/com/cs/quizeloper/user/dto/GetMyQuizSummary.java
@@ -1,0 +1,33 @@
+package com.cs.quizeloper.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GetMyQuizSummary {
+    private Double progressRate;
+    private Double answerRate;
+    private Integer tryNum;
+    private Integer solNum;
+    private Integer successNum;
+    private Integer failureNum;
+
+    public static GetMyQuizSummary toDto(List<Double> rateList, Integer total, Integer solNum, Integer successNum, Integer failureNum) {
+        return GetMyQuizSummary.builder()
+                .progressRate(rateList.get(0))
+                .answerRate(rateList.get(1))
+                .tryNum(total)
+                .solNum(solNum)
+                .successNum(successNum)
+                .failureNum(failureNum)
+                .build();
+    }
+}

--- a/src/main/java/com/cs/quizeloper/user/dto/GetUserQuizHistoryRes.java
+++ b/src/main/java/com/cs/quizeloper/user/dto/GetUserQuizHistoryRes.java
@@ -1,0 +1,35 @@
+package com.cs.quizeloper.user.dto;
+
+import com.cs.quizeloper.quiz.entity.Quiz;
+import com.cs.quizeloper.quiz.entity.QuizType;
+import com.cs.quizeloper.quiz.entity.Stack;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GetUserQuizHistoryRes {
+    private Long quizId;
+    private String title;
+    private QuizType type;
+    private Stack stackUnit;
+    private List<String> quizUnitLists;
+    private Boolean likeYN;
+
+    public static GetUserQuizHistoryRes toDto(Quiz quiz, List<String> quizLists, Boolean likeYN){
+        return GetUserQuizHistoryRes.builder()
+                .quizId(quiz.getId())
+                .title(quiz.getTitle())
+                .type(quiz.getType())
+                .stackUnit(quiz.getStackUnit())
+                .quizUnitLists(quizLists)
+                .likeYN(likeYN)
+                .build();
+    }
+}

--- a/src/main/java/com/cs/quizeloper/user/dto/GetUserQuizRes.java
+++ b/src/main/java/com/cs/quizeloper/user/dto/GetUserQuizRes.java
@@ -1,0 +1,33 @@
+package com.cs.quizeloper.user.dto;
+
+import com.cs.quizeloper.quiz.entity.Quiz;
+import com.cs.quizeloper.quiz.entity.QuizType;
+import com.cs.quizeloper.quiz.entity.Stack;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GetUserQuizRes {
+    private Long quizId;
+    private String title;
+    private QuizType type;
+    private Stack stackUnit;
+    private List<String> quizUnitLists;
+
+    public static GetUserQuizRes toDto(Quiz quiz, List<String> quizLists){
+        return GetUserQuizRes.builder()
+                .quizId(quiz.getId())
+                .title(quiz.getTitle())
+                .type(quiz.getType())
+                .stackUnit(quiz.getStackUnit())
+                .quizUnitLists(quizLists)
+                .build();
+    }
+}

--- a/src/main/java/com/cs/quizeloper/user/service/UserService.java
+++ b/src/main/java/com/cs/quizeloper/user/service/UserService.java
@@ -144,9 +144,15 @@ public class UserService {
         userRepository.delete(user);
     }
 
-    public Page<GetUserQuizRes> getMyQuizList(Long userId, String stack, Pageable pageable){
+    public Page<GetUserQuizRes> getQuizListByStack(Long userId, String stack, Pageable pageable){
         User user = userRepository.findByIdAndStatus(userId, BaseStatus.ACTIVE).orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
         return quizLikeRepository.findAllByOrderByCreatedDateDesc(user, Stack.valueOf(stack.toUpperCase()), ACTIVE, pageable)
+                .map(quiz -> GetUserQuizRes.toDto(quiz, getQuizUnitList(quiz)));
+    }
+
+    public Page<GetUserQuizRes> getQuizList(Long userId, Pageable pageable){
+        User user = userRepository.findByIdAndStatus(userId, BaseStatus.ACTIVE).orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
+        return quizLikeRepository.findAll(user, ACTIVE, pageable)
                 .map(quiz -> GetUserQuizRes.toDto(quiz, getQuizUnitList(quiz)));
     }
 

--- a/src/main/java/com/cs/quizeloper/user/service/UserService.java
+++ b/src/main/java/com/cs/quizeloper/user/service/UserService.java
@@ -156,7 +156,7 @@ public class UserService {
                 .map(quiz -> GetUserQuizRes.toDto(quiz, getQuizUnitList(quiz)));
     }
 
-    public Page<GetUserQuizHistoryRes> getQuizHistoryList(Long userId, String stack, String sorting, String solStatus, Pageable pageable){
+    public Page<GetUserQuizHistoryRes> getQuizHistoryListByStack(Long userId, String stack, String sorting, String solStatus, Pageable pageable){
         User user = userRepository.findByIdAndStatus(userId, BaseStatus.ACTIVE).orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
         List<Long> quizLikes = quizLikeRepository.findAllByUserIdAndStatus(userId, ACTIVE);
         Page<Quiz> quizzes = null;
@@ -165,6 +165,18 @@ public class UserService {
         else if (sorting.equals("past")) { quizzes = quizHistoryRepository.findAllByOrderByCreatedDateAsc(user, Stack.valueOf(stack.toUpperCase()), QuizStatus.valueOf(solStatus.toUpperCase()), ACTIVE, pageable); }
         else if (sorting.equals("large")) { quizzes = quizHistoryRepository.findAllByLarge(user, Stack.valueOf(stack.toUpperCase()), QuizStatus.valueOf(solStatus.toUpperCase()), ACTIVE, pageable); }
         else if (sorting.equals("small")) { quizzes = quizHistoryRepository.findAllBySmall(user, Stack.valueOf(stack.toUpperCase()), QuizStatus.valueOf(solStatus.toUpperCase()), ACTIVE, pageable); }
+        return quizzes.map(quiz -> GetUserQuizHistoryRes.toDto(quiz, getQuizUnitList(quiz), checkUserLikesQuiz(quizLikes, quiz)));
+    }
+
+    public Page<GetUserQuizHistoryRes> getQuizHistoryList(Long userId, String sorting, String solStatus, Pageable pageable){
+        User user = userRepository.findByIdAndStatus(userId, BaseStatus.ACTIVE).orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
+        List<Long> quizLikes = quizLikeRepository.findAllByUserIdAndStatus(userId, ACTIVE);
+        Page<Quiz> quizzes = null;
+        if (sorting == null) { quizzes = quizHistoryRepository.findAll(user, null, ACTIVE, pageable); }
+        else if (sorting.equals("latest")){ quizzes = quizHistoryRepository.findAllByOrderByCreatedDateDesc(user, null, QuizStatus.valueOf(solStatus.toUpperCase()), ACTIVE, pageable); }
+        else if (sorting.equals("past")) { quizzes = quizHistoryRepository.findAllByOrderByCreatedDateAsc(user, null, QuizStatus.valueOf(solStatus.toUpperCase()), ACTIVE, pageable); }
+        else if (sorting.equals("large")) { quizzes = quizHistoryRepository.findAllByLarge(user, null, QuizStatus.valueOf(solStatus.toUpperCase()), ACTIVE, pageable); }
+        else if (sorting.equals("small")) { quizzes = quizHistoryRepository.findAllBySmall(user, null, QuizStatus.valueOf(solStatus.toUpperCase()), ACTIVE, pageable); }
         return quizzes.map(quiz -> GetUserQuizHistoryRes.toDto(quiz, getQuizUnitList(quiz), checkUserLikesQuiz(quizLikes, quiz)));
     }
 


### PR DESCRIPTION
## 🌷 Issue Number
close #51 

<br>

## 📝 Explanation
- 스택별로 진척률, 정답률을 보여줄 수 있도록 uri에 path variable {stack} 추가했습니다.
- **진척도 : 전체 문제 수 / 맞춘 문제 수 (중복 제거), 정답률 : 푼 문제 수 / 맞춘 문제 수 (중복 제거)**
- **시도 문제, 푼 문제 수, 성공 문제 수, 실패 문제 수** 등 퀴즈 요약 페이지에 필요한 데이터들을 불러올 때 쿼리문에서 한번에 불러오게 하려고 했지만 JPQL에서 Distinct 문에 조건 넣는게 안됨 -> 하나의 데이터당 한번씩 쿼리 날리도록 했습니당 ... 무조건 리팩토링 예정 흑흑
